### PR TITLE
Fix a race condition while server shutdown

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -168,15 +168,24 @@ func (s *RedisServer) Run(ctx context.Context) error {
 
 	// now start request/response workers and proxy calls and responses
 	pullArgs = append(pullArgs, redisPullTimeout) //the pull timeout
-	ch := s.Start(ctx, s.workers, s.cb)
+	workerCtx, shutdown := context.WithCancel(context.Background())
+	ch, wg := s.Start(workerCtx, s.workers, s.cb)
+
+	defer func() {
+		shutdown()
+		wg.Wait()
+		close(ch)
+	}()
+
 	for {
 		payload, err := s.getNext(pullArgs)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
+
 		if err == redis.ErrNil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			continue
 		} else if err != nil {
 			log.Error().Err(err).Msg("failed to get next job. Retrying in 1 second")

--- a/redis.go
+++ b/redis.go
@@ -169,7 +169,8 @@ func (s *RedisServer) Run(ctx context.Context) error {
 	// now start request/response workers and proxy calls and responses
 	pullArgs = append(pullArgs, redisPullTimeout) //the pull timeout
 	workerCtx, shutdown := context.WithCancel(context.Background())
-	ch, wg := s.Start(workerCtx, s.workers, s.cb)
+	var wg sync.WaitGroup
+	ch := s.Start(workerCtx, &wg, s.workers, s.cb)
 
 	defer func() {
 		shutdown()

--- a/server_test.go
+++ b/server_test.go
@@ -32,8 +32,8 @@ func TestBaseServer(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-
-	feed, wg := s.Start(ctx, 1, cb)
+	var wg sync.WaitGroup
+	feed := s.Start(ctx, &wg, 1, cb)
 
 	request, err := NewRequest("id", "reply-to", id, "Join", " ", "hello", "world")
 	if ok := assert.NoError(t, err); !ok {
@@ -66,8 +66,8 @@ func TestBaseServerProtocolError(t *testing.T) {
 	cb := func(request *Request, response *Response) {
 		errorMsg = response.Error
 	}
-
-	feed, wg := s.Start(ctx, 1, cb)
+	var wg sync.WaitGroup
+	feed := s.Start(ctx, &wg, 1, cb)
 
 	request, err := NewRequest("id", "reply-to", id, "DoesNotExist", " ", "hello", "world")
 	if ok := assert.NoError(t, err); !ok {
@@ -108,8 +108,8 @@ func TestBaseServerServiceError(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-
-	feed, wg := s.Start(ctx, 1, cb)
+	var wg sync.WaitGroup
+	feed := s.Start(ctx, &wg, 1, cb)
 
 	request, err := NewRequest("id", "reply-to", id, "MakeError")
 	if ok := assert.NoError(t, err); !ok {


### PR DESCRIPTION
What happens is, if we use the same context to
cancel the redis poll and the workers, the order
is not granteed, hence a job can be polled while all workers
are already down. which means a job will be dequeued and never
processes.

In production this can cause clients to block forever waiting for
a job that will never get processed.

The fix is to make sure the redis poll is getting canceled first
and that there are no more job runnings, before stopping the workers
and finally the server loop.