### PR TITLE
Check free worker

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -207,11 +207,10 @@ func (s *RedisServer) Run(ctx context.Context) error {
 			continue
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case ch <- request:
-		}
+		// force wait for a worker to poll
+		// the job (since we sure there is one free)
+		// we don't allow shutting the workers down here.
+		ch <- request
 	}
 }
 

--- a/redis.go
+++ b/redis.go
@@ -179,6 +179,13 @@ func (s *RedisServer) Run(ctx context.Context) error {
 	}()
 
 	for {
+		// wait for free worker before we poll for jobs
+		select {
+		case ch <- &NoOP:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
 		payload, err := s.getNext(pullArgs)
 
 		if err == redis.ErrNil {


### PR DESCRIPTION
The idea is we never poll new jobs until we know there is a free worker for sure. That is also the only place we check if we need to shutdown. But once there is a job polled we have to push it to the worker channel before we check again for shutting down