### PR TITLE
client context + module status

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,9 +4,13 @@ import "context"
 
 // Client defines client interface
 type Client interface {
-	// Request makes a request and return the response data
+	// Request [DEPRECATED] makes a request and return the response data
 	Request(module string, object ObjectID, method string, args ...interface{}) (*Response, error)
+
+	RequestContext(ctx context.Context, module string, object ObjectID, method string, args ...interface{}) (*Response, error)
 
 	// Stream listens to a stream of events from the server
 	Stream(ctx context.Context, module string, object ObjectID, event string) (<-chan Event, error)
+
+	Status(ctx context.Context, module string) (Status, error)
 }

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
+	"time"
 
 	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zbus/examples/server/stubs"
@@ -15,22 +15,26 @@ func main() {
 		panic(err)
 	}
 
-	calculator := stubs.NewCalculatorStub(client)
+	//calculator := stubs.NewCalculatorStub(client)
 	utils := stubs.NewUtilsStub(client)
 
-	fmt.Println(calculator.Add(1, 2, 3, 4))
-	fmt.Println(calculator.Divide(200, 0))
-	fmt.Println(utils.Capitalize("this is awesome"))
-	fmt.Println(utils.Panic())
+	fmt.Println("calling sleep")
+	utils.Sleep(10 * time.Second)
+	fmt.Println("return from sleep")
 
-	fmt.Println("after the panic")
-	ctx := context.Background()
-	ch, err := utils.TikTok(ctx)
-	if err != nil {
-		panic(err)
-	}
-	for time := range ch {
-		fmt.Println(time)
-	}
+	// fmt.Println(calculator.Add(1, 2, 3, 4))
+	// fmt.Println(calculator.Divide(200, 0))
+	// fmt.Println(utils.Capitalize("this is awesome"))
+	// fmt.Println(utils.Panic())
+
+	// fmt.Println("after the panic")
+	// ctx := context.Background()
+	// ch, err := utils.TikTok(ctx)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// for time := range ch {
+	// 	fmt.Println(time)
+	// }
 
 }

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"time"
 
 	"github.com/threefoldtech/zbus"
 	"github.com/threefoldtech/zbus/examples/server/stubs"
@@ -15,26 +15,22 @@ func main() {
 		panic(err)
 	}
 
-	//calculator := stubs.NewCalculatorStub(client)
+	calculator := stubs.NewCalculatorStub(client)
 	utils := stubs.NewUtilsStub(client)
 
-	fmt.Println("calling sleep")
-	utils.Sleep(10 * time.Second)
-	fmt.Println("return from sleep")
+	fmt.Println(calculator.Add(1, 2, 3, 4))
+	fmt.Println(calculator.Divide(200, 0))
+	fmt.Println(utils.Capitalize("this is awesome"))
+	fmt.Println(utils.Panic())
 
-	// fmt.Println(calculator.Add(1, 2, 3, 4))
-	// fmt.Println(calculator.Divide(200, 0))
-	// fmt.Println(utils.Capitalize("this is awesome"))
-	// fmt.Println(utils.Panic())
-
-	// fmt.Println("after the panic")
-	// ctx := context.Background()
-	// ch, err := utils.TikTok(ctx)
-	// if err != nil {
-	// 	panic(err)
-	// }
-	// for time := range ch {
-	// 	fmt.Println(time)
-	// }
+	fmt.Println("after the panic")
+	ctx := context.Background()
+	ch, err := utils.TikTok(ctx)
+	if err != nil {
+		panic(err)
+	}
+	for time := range ch {
+		fmt.Println(time)
+	}
 
 }

--- a/examples/server/api/api.go
+++ b/examples/server/api/api.go
@@ -22,4 +22,5 @@ type Utils interface {
 	Capitalize(s string) string
 	TikTok(ctx context.Context) <-chan time.Time // event
 	Panic() int
+	Sleep(t time.Duration) error
 }

--- a/examples/server/stubs/utils_stub.go
+++ b/examples/server/stubs/utils_stub.go
@@ -47,6 +47,19 @@ func (s *UtilsStub) Panic() (ret0 int) {
 	return
 }
 
+func (s *UtilsStub) Sleep(arg0 time.Duration) (ret0 error) {
+	args := []interface{}{arg0}
+	result, err := s.client.Request(s.module, s.object, "Sleep", args...)
+	if err != nil {
+		panic(err)
+	}
+	ret0 = new(zbus.RemoteError)
+	if err := result.Unmarshal(0, &ret0); err != nil {
+		panic(err)
+	}
+	return
+}
+
 func (s *UtilsStub) TikTok(ctx context.Context) (<-chan time.Time, error) {
 	ch := make(chan time.Time)
 	recv, err := s.client.Stream(ctx, s.module, s.object, "TikTok")

--- a/generation/generation.go
+++ b/generation/generation.go
@@ -205,6 +205,7 @@ func getMethodBody(m *reflect.Method) []jen.Code {
 	}
 
 	inputs := []jen.Code{
+		jen.Id("ctx"),
 		jen.Id("s").Dot("module"),
 		jen.Id("s").Dot("object"),
 		jen.Lit(m.Name),
@@ -213,7 +214,7 @@ func getMethodBody(m *reflect.Method) []jen.Code {
 
 	code = append(
 		code,
-		jen.List(jen.Id("result"), jen.Id("err")).Op(":=").Id("s").Dot("client").Dot("Request").
+		jen.List(jen.Id("result"), jen.Id("err")).Op(":=").Id("s").Dot("client").Dot("RequestContext").
 			Call(inputs...),
 		jen.If(
 			jen.Id("err").Op("!=").Nil().Block(
@@ -288,7 +289,10 @@ func getTypeCode(s *jen.Statement, t reflect.Type) *jen.Statement {
 }
 
 func getMethodParams(m *reflect.Method) []jen.Code {
-	var code []jen.Code
+	code := []jen.Code{
+		jen.Id("ctx").Qual("context", "Context"),
+	}
+
 	typ := m.Type
 	for i := 0; i < typ.NumIn(); i++ {
 		argName := fmt.Sprintf("%s%d", ArgumentPrefix, i)

--- a/server.go
+++ b/server.go
@@ -39,15 +39,15 @@ type WorkerState string
 // WorkerStatus represents the full worker status including request time and method
 // that it is working on.
 type WorkerStatus struct {
-	State     WorkerState `json:"state"`
-	StartTime time.Time   `json:"time,omitempty"`
-	Action    string      `json:"action,omitempty"`
+	State     WorkerState `json:"state" yaml:"state"`
+	StartTime time.Time   `json:"time,omitempty" yaml:"time,omitempty"`
+	Action    string      `json:"action,omitempty" yaml:"action,omitempty"`
 }
 
 // Status is returned by the server Status method
 type Status struct {
-	Objects []ObjectID
-	Workers []WorkerStatus
+	Objects []ObjectID     `json:"objects" yaml:"objects"`
+	Workers []WorkerStatus `json:"workers" yaml:"workers"`
 }
 
 // BaseServer implements the basic server functionality


### PR DESCRIPTION
This PR provides 2 improvements
- Support a status method on the low level client to check status of a specific module, the status call returns names, and versions of registered objects + list of all workers and their current status.
- Support `RequestContext` method in the low level client.
- Changes to `zbusc` to generate stubs to use the RequestContext.